### PR TITLE
increasing amount of times to not complete

### DIFF
--- a/marathon/resource_marathon_app.go
+++ b/marathon/resource_marathon_app.go
@@ -330,6 +330,7 @@ func resourceMarathonAppCreate(d *schema.ResourceData, meta interface{}) error {
 		Timeout:    10 * time.Minute,
 		Delay:      1 * time.Second,
 		MinTimeout: 1 * time.Second,
+		NotFoundChecks: 60,
 	}
 
 	_, err = stateConf.WaitForState()


### PR DESCRIPTION
The `NotFoundChecks` was defaulting to 20 when not given, which with the delays between each try it only tried for about ~2.5 minutes.  This sets it so it's closer to the 10 minutes we have for the `Timeout`.
