### PR TITLE
adding timeouts for requests and deployments

### DIFF
--- a/marathon/config.go
+++ b/marathon/config.go
@@ -3,11 +3,13 @@ package marathon
 import (
 	"github.com/gambol99/go-marathon"
 	"os"
+	"time"
 )
 
 type Config struct {
-	Url            string
-	RequestTimeout int
+	Url                      string
+	RequestTimeout           int
+	DefaultDeploymentTimeout time.Duration
 
 	client marathon.Marathon
 }
@@ -18,6 +20,7 @@ func (c *Config) loadAndValidate() error {
 	config := marathon.NewDefaultConfig()
 	config.URL = c.Url
 	config.RequestTimeout = c.RequestTimeout
+	config.DefaultDeploymentTimeout = c.DefaultDeploymentTimeout
 	config.LogOutput = os.Stdout
 
 	client, err := marathon.NewClient(config)

--- a/marathon/provider.go
+++ b/marathon/provider.go
@@ -3,6 +3,7 @@ package marathon
 import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"time"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -20,6 +21,12 @@ func Provider() terraform.ResourceProvider {
 				Default:     10,
 				Description: "'Request Timeout",
 			},
+			"deployment_timeout": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     600,
+				Description: "'Deployment Timeout",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -32,8 +39,9 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Url:            d.Get("url").(string),
-		RequestTimeout: d.Get("request_timeout").(int),
+		Url:                      d.Get("url").(string),
+		RequestTimeout:           d.Get("request_timeout").(int),
+		DefaultDeploymentTimeout: time.Duration(d.Get("deployment_timeout").(int)) * time.Second,
 	}
 
 	if err := config.loadAndValidate(); err != nil {


### PR DESCRIPTION
requires https://github.com/gambol99/go-marathon/pull/45

i tested against https://github.com/Banno/big/pull/210, however, the
docker daemons in the mesos slaves were having problems pulling. i
didn't look into that anymore.
