### PR TITLE
initial support for basic-auth enabled marathon endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,26 @@ provider "marathon" {
 }
 ```
 
+If Marathon endpoint requires basic auth (with TLS, hopefully), optionally include username and password:
+```bash
+$ export TF_VAR_marathon_url="https://marthon.domain.tld:8443"
+$ export TF_VAR_marathon_user="username"
+$ export TF_VAR_marathon_password="password"
+
+```
+
+```hcl
+variable "marathon_url" {}
+variable "marathon_user" {}
+variable "marathon_password" {}
+
+provider "marathon" {
+  url = "${var.marathon_url}"
+  basic_auth_user = "${var.marathon_user}"
+  basic_auth_password = "${var.marathon_password}"
+}
+```
+
 ### Basic Usage
 ```hcl
 resource "marathon_app" "hello-world" {

--- a/marathon/config.go
+++ b/marathon/config.go
@@ -9,6 +9,8 @@ type Config struct {
 	Url                      string
 	RequestTimeout           int
 	DefaultDeploymentTimeout time.Duration
+	BasicAuthUser            string
+	BasicAuthPassword        string
 
 	Client marathon.Marathon
 }
@@ -19,6 +21,8 @@ func (c *Config) loadAndValidate() error {
 	marathonConfig := marathon.NewDefaultConfig()
 	marathonConfig.URL = c.Url
 	marathonConfig.RequestTimeout = c.RequestTimeout
+	marathonConfig.HTTPBasicAuthUser = c.BasicAuthUser
+	marathonConfig.HTTPBasicPassword = c.BasicAuthPassword
 
 	client, err := marathon.NewClient(marathonConfig)
 	c.Client = client

--- a/marathon/provider.go
+++ b/marathon/provider.go
@@ -27,6 +27,16 @@ func Provider() terraform.ResourceProvider {
 				Default:     600,
 				Description: "'Deployment Timeout",
 			},
+			"basic_auth_user": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "HTTP basic auth user",
+			},
+			"basic_auth_password": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "HTTP basic auth password",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -42,6 +52,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Url:                      d.Get("url").(string),
 		RequestTimeout:           d.Get("request_timeout").(int),
 		DefaultDeploymentTimeout: time.Duration(d.Get("deployment_timeout").(int)) * time.Second,
+		BasicAuthUser:            d.Get("basic_auth_user").(string),
+		BasicAuthPassword:        d.Get("basic_auth_password").(string),
 	}
 
 	if err := config.loadAndValidate(); err != nil {


### PR DESCRIPTION
Verified this functions with https and http endpoints.  It simply leverages the support already present in go-marathon - it was simple wiring.  I didn't update the test framework (yet), as I wasn't sure if you wanted that dependency.