### PR TITLE
Fix: health check attributes `path` and `timeout_seconds`

### DIFF
--- a/marathon/resource_marathon_app.go
+++ b/marathon/resource_marathon_app.go
@@ -822,6 +822,7 @@ func mutateResourceToApplication(d *schema.ResourceData) *marathon.Application {
 				commandMap := commands[0].(map[string]interface{})
 				healthCheck.Command = &marathon.Command{Value: commandMap["value"].(string)}
 				healthCheck.Protocol = "COMMAND"
+				healthCheck.Path = ""
 			} else {
 				if prop, ok := mapStruct["path"]; ok {
 					prop := prop.(string)
@@ -836,10 +837,10 @@ func mutateResourceToApplication(d *schema.ResourceData) *marathon.Application {
 				if prop, ok := mapStruct["protocol"]; ok {
 					healthCheck.Protocol = prop.(string)
 				}
+			}
 
-				if prop, ok := mapStruct["timeout_seconds"]; ok {
-					healthCheck.TimeoutSeconds = prop.(int)
-				}
+			if prop, ok := mapStruct["timeout_seconds"]; ok {
+				healthCheck.TimeoutSeconds = prop.(int)
 			}
 
 			if prop, ok := mapStruct["grace_period_seconds"]; ok {


### PR DESCRIPTION
Fix: health check attributes `path` and `timeout_seconds` were stored properly in Marathon but not respected in the provider

 With health check defined as COMMAND:
 ```
health_checks {
    health_check {
        protocol = "COMMAND"
        command = {
            value = "sleep 1"
        }
        grace_period_seconds = 5
        interval_seconds = 15
        max_consecutive_failures = 2
        timeout_seconds = 5
    }
}
```

Creation of the resource went properly, all the attributes stored in Marathon. But when re-running the provider without any changes to the resource, the following diff appeared:
```
~ marathon_app.some_application
    health_checks.0.health_check.0.path:            "" => "/"
    health_checks.0.health_check.0.timeout_seconds: "20" => "5"
```