### PR TITLE
Change parameter struct to allow multiple use of the same option

### DIFF
--- a/test/example.tf
+++ b/test/example.tf
@@ -20,7 +20,10 @@ resource "marathon_app" "app-create-example" {
       image = "python:3"
       network = "BRIDGE"
       parameters {
-        hostname = "a.corp.org"
+        parameters {
+          key = "hostname"
+          value = "a.corp.org"
+        }
       }
       port_mappings {
         port_mapping {

--- a/test/example.tf
+++ b/test/example.tf
@@ -20,7 +20,7 @@ resource "marathon_app" "app-create-example" {
       image = "python:3"
       network = "BRIDGE"
       parameters {
-        parameters {
+        parameter {
           key = "hostname"
           value = "a.corp.org"
         }


### PR DESCRIPTION
The current format of the provider doesn't allow to use multiple time
  the same option, it can be useful for some docker option (log-opt).

Syntax change:
Old:
```
parameters {
   hostname = "a.corp.org"
}
```

New:
```
parameters {
  parameter {
    key = "hostname"
    value = "a.corp.org"
  }
}
```