### PR TITLE
Use the event stream to determine deployment status

### DIFF
--- a/marathon/provider.go
+++ b/marathon/provider.go
@@ -71,6 +71,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if d.Get("log_output").(bool) {
 		marathonConfig.LogOutput = logWriter{}
 	}
+	marathonConfig.EventsTransport = marathon.EventsTransportSSE
 
 	config := config{
 		config: marathonConfig,


### PR DESCRIPTION
An alternative fix for https://github.com/Banno/terraform-provider-marathon/issues/34

Avoid the fickle deployments api and use the Events api instead.