### PR TITLE
Remove big from tests and replace it with public docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+marathon:
+  image: mesosphere/marathon:v1.3.5
+  container_name: tf-marathon
+  ports:
+    - "8080:8080"
+  command: --master zk://zookeeper:2181/mesos --zk zk://zookeeper:2181/marathon
+  links:
+    - zookeeper
+    - mesos-slave
+
+mesos-master:
+  image: mesosphere/mesos-master:1.0.0
+  environment:
+    MESOS_PORT: 5050
+    MESOS_ZK: zk://zookeeper:2181/mesos
+    MESOS_QUORUM: 1
+    MESOS_REGISTRY: in_memory
+  ports:
+    - "5050:5050"
+  links:
+    - zookeeper
+    - mesos-slave
+
+mesos-slave:
+  image: mesosphere/mesos-slave:1.0.0
+  environment:
+    MESOS_PORT: 5051
+    MESOS_MASTER: zk://zookeeper:2181/mesos
+    MESOS_SWITCH_USER: 0
+    MESOS_CONTAINERIZERS: docker,mesos
+    MESOS_WORK_DIR: /tmp
+  ports:
+    - "5051:5051"
+  links:
+    - zookeeper
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /cgroup:/cgroup
+    - /sys:/sys
+    - /usr/local/bin/docker:/usr/local/bin/docker
+
+test:
+  build: test
+  volumes:
+    - ./:/go/src/github.com/Banno/terraform-provider-marathon/
+  links:
+    - marathon
+
+zookeeper:
+  image: jplock/zookeeper:3.4.9
+  ports:
+    - "2181:2181"

--- a/makefile
+++ b/makefile
@@ -13,10 +13,14 @@ build: vet osx linux
 	go install .
 
 test: build
-	big inventory add marathon
-	big up -d marathon
+	docker pull python:3
+	docker-compose build test
+	docker-compose pull
+	docker-compose up -d marathon mesos-master mesos-slave zookeeper
 	sleep 5
-	TF_LOG=TRACE TF_LOG_PATH=./test-sh-tf.log TF_ACC=yes MARATHON_URL=https://marathon.dev.banno.com go test ./marathon -v
+	docker-compose up test
+	docker-compose kill
+	docker-compose rm -f
 
 release:
 	./bin/release.sh

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.7
+ENV GOPATH=/go
+ENV TF_LOG=TRACE
+ENV TF_LOG_PATH=/go/src/github.com/Banno/terraform-provider-marathon/marathon/test-sh-tf.log
+ENV TF_ACC=yes
+ENV MARATHON_URL=http://marathon:8080
+
+WORKDIR /go/src/github.com/Banno/terraform-provider-marathon/marathon/
+
+ADD test.sh /test
+CMD ["/test"]

--- a/test/example.tf
+++ b/test/example.tf
@@ -1,7 +1,7 @@
 resource "marathon_app" "app-create-example" {
   app_id = "/app-create-example"
 
-  cmd = "env && python3 -m http.server 8080"
+  cmd = "env && python3 -m http.server $PORT0"
 
   constraints {
     constraint {
@@ -18,18 +18,6 @@ resource "marathon_app" "app-create-example" {
         parameter {
           key = "hostname"
           value = "a.corp.org"
-        }
-      }
-      port_mappings {
-        port_mapping {
-          container_port = 8080
-          host_port = 0
-          protocol = "tcp"
-        }
-        port_mapping {
-          container_port = 161
-          host_port = 0
-          protocol = "udp"
         }
       }
     }
@@ -57,15 +45,6 @@ resource "marathon_app" "app-create-example" {
 
   health_checks {
     health_check {
-      grace_period_seconds = 3
-      interval_seconds = 10
-      max_consecutive_failures = 0
-      path = "/"
-      port_index = 0
-      protocol = "HTTP"
-      timeout_seconds = 5
-    }
-    health_check {
       command {
         value = "curl -f -X GET http://$HOST:$PORT0/"
       }
@@ -79,11 +58,9 @@ resource "marathon_app" "app-create-example" {
     test = "abc"
   }
   mem = 50
-  ports = [0, 0]
+  ports = [0]
 
   upgrade_strategy {
     minimum_health_capacity = "0.5"
   }
-
-  # dependencies = ["/test"]
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+go list github.com/Banno/terraform-provider-marathon \
+    | xargs go list -f '{{join .Deps "\n"}}' \
+    | grep -v github.com/Banno/terraform-provider-marathon \
+    | sort -u \
+    | xargs go get -f -u -v
+
+go test -v .


### PR DESCRIPTION
This will let folks run the test setup without Banno specific tools.

See: https://github.com/Banno/terraform-provider-marathon/pull/37
