### PR TITLE
fix timeout being reached on eventlistener

### DIFF
--- a/marathon/provider.go
+++ b/marathon/provider.go
@@ -73,6 +73,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 	marathonConfig.EventsTransport = marathon.EventsTransportSSE
 
+	marathonConfig.HTTPClient = &http.Client{
+		Timeout: (time.Duration(d.Get("deployment_timeout").(int)) * time.Second),
+	}
+
 	config := config{
 		config: marathonConfig,
 		DefaultDeploymentTimeout: time.Duration(d.Get("deployment_timeout").(int)) * time.Second,


### PR DESCRIPTION
- wait for eventlistener to come up
- increase timeout from 10s to deployment_timeout
- don't return on the first successful/failed deployment
- keep a buffer of events just in case deployments are done in subsecond speed (being a bit too cautious here I guess)