### PR TITLE
Add support for DCOS and/or custom marathon paths

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/Banno/terraform-provider-marathon",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v75",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
@@ -149,8 +149,8 @@
 		},
 		{
 			"ImportPath": "github.com/gambol99/go-marathon",
-			"Comment": "v0.5.1",
-			"Rev": "40baf7476c1cc627a75039ce6d99a7c06c2dbdbe"
+			"Comment": "v0.7.1-1-gced6005",
+			"Rev": "ced60055f074477c61ef886423f317acfd8fbf4a"
 		},
 		{
 			"ImportPath": "github.com/go-ini/ini",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,25 @@ provider "marathon" {
 }
 ```
 
+To use Marathon from a DCOS cluster you need to get a [token](https://dcos.io/docs/1.8/administration/id-and-access-mgt/iam-api/) and include the [framework path](https://docs.mesosphere.com/1.8/usage/service-guides/marathon/install) in the Marathon URL:
+
+```bash
+export TF_VAR_marathon_url="http://dcos.domain.tld/service/marathon"
+export TF_VAR_dcos_token="<authentication-token>"
+```
+
+```hcl
+variable "marathon_url" {}
+variable "dcos_token" {}
+
+provider "marathon" {
+  url        = "${var.marathon_url}"
+  dcos_token = "${var.dcos_token}"
+}
+```
+
+If you have an additional Marathon instance called *marathon-alice* set *marathon_url* to `http://dcos.domain.tld/service/marathon-alice`. Refer to the *go-marathon* [documentation](https://github.com/gambol99/go-marathon/blob/master/README.md#creating-a-client) to get details about custom paths in Marathon URLs.
+
 ### Basic Usage
 ```hcl
 resource "marathon_app" "hello-world" {

--- a/marathon/provider.go
+++ b/marathon/provider.go
@@ -44,6 +44,18 @@ func Provider() terraform.ResourceProvider {
 				Default:     "",
 				Description: "HTTP basic auth password",
 			},
+			"dcos_token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "DCOS token",
+			},
+			"dcos_path": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "marathon",
+				Description: "DCOS path",
+			},
 			"log_output": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -69,6 +81,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 	marathonConfig.HTTPBasicAuthUser = d.Get("basic_auth_user").(string)
 	marathonConfig.HTTPBasicPassword = d.Get("basic_auth_password").(string)
+	marathonConfig.DCOSToken = d.Get("dcos_token").(string)
+	marathonConfig.DCOSPath = d.Get("dcos_path").(string)
 	if d.Get("log_output").(bool) {
 		marathonConfig.LogOutput = logWriter{}
 	}

--- a/marathon/provider.go
+++ b/marathon/provider.go
@@ -50,12 +50,6 @@ func Provider() terraform.ResourceProvider {
 				Default:     "",
 				Description: "DCOS token",
 			},
-			"dcos_path": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				Default:     "marathon",
-				Description: "DCOS path",
-			},
 			"log_output": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -82,7 +76,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	marathonConfig.HTTPBasicAuthUser = d.Get("basic_auth_user").(string)
 	marathonConfig.HTTPBasicPassword = d.Get("basic_auth_password").(string)
 	marathonConfig.DCOSToken = d.Get("dcos_token").(string)
-	marathonConfig.DCOSPath = d.Get("dcos_path").(string)
 	if d.Get("log_output").(bool) {
 		marathonConfig.LogOutput = logWriter{}
 	}

--- a/marathon/resource_marathon_app.go
+++ b/marathon/resource_marathon_app.go
@@ -858,7 +858,7 @@ func mutateResourceToApplication(d *schema.ResourceData) *marathon.Application {
 		discovery = discovery.EmptyPorts()
 
 		ipAddressPerTask := new(marathon.IPAddressPerTask)
-		ipAddressPerTask.Discovery = *discovery
+		ipAddressPerTask.Discovery = discovery
 
 		ipAddressPerTask.NetworkName = t
 
@@ -1097,11 +1097,11 @@ func mutateResourceToApplication(d *schema.ResourceData) *marathon.Application {
 	upgradeStrategy := &marathon.UpgradeStrategy{}
 
 	if v, ok := d.GetOk("upgrade_strategy.0.minimum_health_capacity"); ok {
-		upgradeStrategy.MinimumHealthCapacity = v.(float64)
+		upgradeStrategy.MinimumHealthCapacity = v.(*float64)
 	}
 
 	if v, ok := d.GetOk("upgrade_strategy.0.maximum_over_capacity"); ok {
-		upgradeStrategy.MaximumOverCapacity = v.(float64)
+		upgradeStrategy.MaximumOverCapacity = v.(*float64)
 	}
 
 	application.UpgradeStrategy = upgradeStrategy

--- a/vendor/github.com/gambol99/go-marathon/.gitignore
+++ b/vendor/github.com/gambol99/go-marathon/.gitignore
@@ -7,9 +7,13 @@ go-marathon.iml
 Gemfile.lock
 thin.*
 examples/applications/applications
-examples/multiple_endpoints/multiple_endpoints
-examples/subscription/subscription
+examples/events_callback_transport/events_callback_transport
+examples/events_sse_transport/events_sse_transport
+examples/glog/glog
 examples/groups/groups
+examples/multiple_endpoints/multiple_endpoints
+examples/queue/queue
+examples/tasks/tasks
 
 # Folders
 _obj
@@ -31,8 +35,4 @@ _testmain.go
 *.test
 *.prof
 
-
-
-examples/events/events
 tests/rest-api/rest-api
-examples/tasks/tasks

--- a/vendor/github.com/gambol99/go-marathon/.travis.yml
+++ b/vendor/github.com/gambol99/go-marathon/.travis.yml
@@ -9,5 +9,6 @@ go:
   - 1.5
   - 1.6
   - 1.7
+  - 1.8
 install:
-  - make test examples
+  - make check-format test examples

--- a/vendor/github.com/gambol99/go-marathon/AUTHORS
+++ b/vendor/github.com/gambol99/go-marathon/AUTHORS
@@ -24,6 +24,7 @@ Luke Amdor <luke.amdor@gmail.com>
 Maarten Dirkse <mdirkse@bol.com>
 Marcelo Salazar <chelosalazar@gmail.com>
 Marvin Hoffmann <contact@marvin-hoffmann.de>
+Matt DeBoer <matt.deboer@gmail.com>
 Matthias Kadenbach <matthias.kadenbach@gmail.com>
 Mike Solomon <mikesol@gmail.com>
 Mikhail Dyakov <wtltl2@gmail.com>

--- a/vendor/github.com/gambol99/go-marathon/CHANGELOG.md
+++ b/vendor/github.com/gambol99/go-marathon/CHANGELOG.md
@@ -5,6 +5,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [#267][PR267] Add DCOS path parameter for additional marathon instances.
+
+## [0.7.1] - 2017-02-20
+### Fixed
+- [#261][PR261] Fix URL parsing for Go 1.8.
+
+## [0.7.0] - 2017-02-17
+### Added
+- [#256][PR256] Expose task state.
+
+### Changed
+- [#259][PR259] Add 'omitempty' to UpgradeStrategy properties.
+
+## [0.6.0] - 2016-12-14
+### Added
+- [#246][PR246] Add TaskKillGracePeriodSeconds support.
+- [#244][PR244] Add taskStats support.
+
+### Changed
+- [#242][PR242] Pointerize IPAddressPerTask.Discovery.
 
 ## [0.5.1] - 2016-11-09
 ### Fixed
@@ -87,7 +108,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial SemVer release.
 
-[Unreleased]: https://github.com/gambol99/go-marathon/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/gambol99/go-marathon/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/gambol99/go-marathon/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/gambol99/go-marathon/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/gambol99/go-marathon/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/gambol99/go-marathon/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/gambol99/go-marathon/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/gambol99/go-marathon/compare/v0.3.0...v0.4.0
@@ -96,6 +120,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [0.1.1]: https://github.com/gambol99/go-marathon/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gambol99/go-marathon/compare/v0.0.1...v0.1.0
 
+[PR267]: https://github.com/gambol99/go-marathon/pull/267
+[PR261]: https://github.com/gambol99/go-marathon/pull/261
+[PR259]: https://github.com/gambol99/go-marathon/pull/259
+[PR256]: https://github.com/gambol99/go-marathon/pull/256
+[PR246]: https://github.com/gambol99/go-marathon/pull/246
+[PR244]: https://github.com/gambol99/go-marathon/pull/244
+[PR242]: https://github.com/gambol99/go-marathon/pull/242
 [PR239]: https://github.com/gambol99/go-marathon/pull/239
 [PR231]: https://github.com/gambol99/go-marathon/pull/231
 [PR229]: https://github.com/gambol99/go-marathon/pull/229

--- a/vendor/github.com/gambol99/go-marathon/Makefile
+++ b/vendor/github.com/gambol99/go-marathon/Makefile
@@ -10,7 +10,7 @@ DEPS=$(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 PACKAGES=$(shell go list ./...)
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 
-.PHONY: test examples authors changelog
+.PHONY: test examples authors changelog check-format
 
 build:
 	go build
@@ -44,9 +44,18 @@ format:
 	@echo "--> Running go fmt"
 	@go fmt $(PACKAGES)
 
+check-format:
+	@echo "--> Checking format"
+	@if gofmt -l . 2>&1 | grep -q '.go'; then \
+		echo "found unformatted files:"; \
+		echo; \
+		gofmt -l .; \
+		exit 1; \
+	fi
+
 test: deps
 	@echo "--> Running go tests"
-	@go test -v
+	@go test -race -v
 	@$(MAKE) vet
 	@$(MAKE) cover
 

--- a/vendor/github.com/gambol99/go-marathon/README.md
+++ b/vendor/github.com/gambol99/go-marathon/README.md
@@ -50,6 +50,14 @@ marathonURL := "http://10.241.1.71:8080,10.241.1.72:8080,10.241.1.73:8080"
 The first one specified will be used, if that goes offline the member is marked as *"unavailable"* and a
 background process will continue to ping the member until it's back online.
 
+You can also pass a custom path to the URL, which is especially needed in case of DCOS:
+
+```Go
+marathonURL := "http://10.241.1.71:8080/cluster,10.241.1.72:8080/cluster,10.241.1.73:8080/cluster"
+```
+
+If you specify a `DCOSToken` in the configuration file but do not pass a custom URL path, `/marathon` will be used.
+
 ### Custom HTTP Client
 
 If you wish to override the http client (by default http.DefaultClient) used by the API; use cases bypassing TLS verification, load root CA's or change the timeouts etc, you can pass a custom client in the config.

--- a/vendor/github.com/gambol99/go-marathon/application.go
+++ b/vendor/github.com/gambol99/go-marathon/application.go
@@ -38,7 +38,7 @@ type Applications struct {
 type IPAddressPerTask struct {
 	Groups      *[]string          `json:"groups,omitempty"`
 	Labels      *map[string]string `json:"labels,omitempty"`
-	Discovery   Discovery          `json:"discovery,omitempty"`
+	Discovery   *Discovery         `json:"discovery,omitempty"`
 	NetworkName string             `json:"networkName,omitempty"`
 }
 
@@ -56,41 +56,43 @@ type Port struct {
 
 // Application is the definition for an application in marathon
 type Application struct {
-	ID                    string              `json:"id,omitempty"`
-	Cmd                   *string             `json:"cmd,omitempty"`
-	Args                  *[]string           `json:"args,omitempty"`
-	Constraints           *[][]string         `json:"constraints,omitempty"`
-	Container             *Container          `json:"container,omitempty"`
-	CPUs                  float64             `json:"cpus,omitempty"`
-	Disk                  *float64            `json:"disk,omitempty"`
-	Env                   *map[string]string  `json:"env,omitempty"`
-	Executor              *string             `json:"executor,omitempty"`
-	HealthChecks          *[]HealthCheck      `json:"healthChecks,omitempty"`
-	Instances             *int                `json:"instances,omitempty"`
-	Mem                   *float64            `json:"mem,omitempty"`
-	Tasks                 []*Task             `json:"tasks,omitempty"`
-	Ports                 []int               `json:"ports"`
-	PortDefinitions       *[]PortDefinition   `json:"portDefinitions,omitempty"`
-	RequirePorts          *bool               `json:"requirePorts,omitempty"`
-	BackoffSeconds        *float64            `json:"backoffSeconds,omitempty"`
-	BackoffFactor         *float64            `json:"backoffFactor,omitempty"`
-	MaxLaunchDelaySeconds *float64            `json:"maxLaunchDelaySeconds,omitempty"`
-	Deployments           []map[string]string `json:"deployments,omitempty"`
-	Dependencies          []string            `json:"dependencies"`
-	TasksRunning          int                 `json:"tasksRunning,omitempty"`
-	TasksStaged           int                 `json:"tasksStaged,omitempty"`
-	TasksHealthy          int                 `json:"tasksHealthy,omitempty"`
-	TasksUnhealthy        int                 `json:"tasksUnhealthy,omitempty"`
-	User                  string              `json:"user,omitempty"`
-	UpgradeStrategy       *UpgradeStrategy    `json:"upgradeStrategy,omitempty"`
-	Uris                  *[]string           `json:"uris,omitempty"`
-	Version               string              `json:"version,omitempty"`
-	VersionInfo           *VersionInfo        `json:"versionInfo,omitempty"`
-	Labels                *map[string]string  `json:"labels,omitempty"`
-	AcceptedResourceRoles []string            `json:"acceptedResourceRoles,omitempty"`
-	LastTaskFailure       *LastTaskFailure    `json:"lastTaskFailure,omitempty"`
-	Fetch                 *[]Fetch            `json:"fetch,omitempty"`
-	IPAddressPerTask      *IPAddressPerTask   `json:"ipAddress,omitempty"`
+	ID                         string               `json:"id,omitempty"`
+	Cmd                        *string              `json:"cmd,omitempty"`
+	Args                       *[]string            `json:"args,omitempty"`
+	Constraints                *[][]string          `json:"constraints,omitempty"`
+	Container                  *Container           `json:"container,omitempty"`
+	CPUs                       float64              `json:"cpus,omitempty"`
+	Disk                       *float64             `json:"disk,omitempty"`
+	Env                        *map[string]string   `json:"env,omitempty"`
+	Executor                   *string              `json:"executor,omitempty"`
+	HealthChecks               *[]HealthCheck       `json:"healthChecks,omitempty"`
+	Instances                  *int                 `json:"instances,omitempty"`
+	Mem                        *float64             `json:"mem,omitempty"`
+	Tasks                      []*Task              `json:"tasks,omitempty"`
+	Ports                      []int                `json:"ports"`
+	PortDefinitions            *[]PortDefinition    `json:"portDefinitions,omitempty"`
+	RequirePorts               *bool                `json:"requirePorts,omitempty"`
+	BackoffSeconds             *float64             `json:"backoffSeconds,omitempty"`
+	BackoffFactor              *float64             `json:"backoffFactor,omitempty"`
+	MaxLaunchDelaySeconds      *float64             `json:"maxLaunchDelaySeconds,omitempty"`
+	TaskKillGracePeriodSeconds *float64             `json:"taskKillGracePeriodSeconds,omitempty"`
+	Deployments                []map[string]string  `json:"deployments,omitempty"`
+	Dependencies               []string             `json:"dependencies"`
+	TasksRunning               int                  `json:"tasksRunning,omitempty"`
+	TasksStaged                int                  `json:"tasksStaged,omitempty"`
+	TasksHealthy               int                  `json:"tasksHealthy,omitempty"`
+	TasksUnhealthy             int                  `json:"tasksUnhealthy,omitempty"`
+	TaskStats                  map[string]TaskStats `json:"taskStats,omitempty"`
+	User                       string               `json:"user,omitempty"`
+	UpgradeStrategy            *UpgradeStrategy     `json:"upgradeStrategy,omitempty"`
+	Uris                       *[]string            `json:"uris,omitempty"`
+	Version                    string               `json:"version,omitempty"`
+	VersionInfo                *VersionInfo         `json:"versionInfo,omitempty"`
+	Labels                     *map[string]string   `json:"labels,omitempty"`
+	AcceptedResourceRoles      []string             `json:"acceptedResourceRoles,omitempty"`
+	LastTaskFailure            *LastTaskFailure     `json:"lastTaskFailure,omitempty"`
+	Fetch                      *[]Fetch             `json:"fetch,omitempty"`
+	IPAddressPerTask           *IPAddressPerTask    `json:"ipAddress,omitempty"`
 }
 
 // ApplicationVersions is a collection of application versions for a specific app in marathon
@@ -128,6 +130,17 @@ type GetAppOpts struct {
 //		force:		overrides a currently running deployment.
 type DeleteAppOpts struct {
 	Force bool `url:"force,omitempty"`
+}
+
+// TaskStats is a container for Stats
+type TaskStats struct {
+	Stats Stats `json:"stats"`
+}
+
+// Stats is a collection of aggregate statistics about an application's tasks
+type Stats struct {
+	Counts   map[string]int     `json:"counts"`
+	LifeTime map[string]float64 `json:"lifeTime"`
 }
 
 // SetIPAddressPerTask defines that the application will have a IP address defines by a external agent.
@@ -238,6 +251,16 @@ func (r *Application) EmptyPortDefinitions() *Application {
 //		count:	the number of instances to run
 func (r *Application) Count(count int) *Application {
 	r.Instances = &count
+
+	return r
+}
+
+// SetTaskKillGracePeriod sets the number of seconds between escalating from SIGTERM to SIGKILL
+// when signalling tasks to terminate. Using this grace period, tasks should perform orderly shut down
+// immediately upon receiving SIGTERM.
+//		seconds:	the number of seconds
+func (r *Application) SetTaskKillGracePeriod(seconds float64) *Application {
+	r.TaskKillGracePeriodSeconds = &seconds
 
 	return r
 }
@@ -475,6 +498,20 @@ func (r *Application) AddFetchURIs(fetchURIs ...Fetch) *Application {
 func (r *Application) EmptyFetchURIs() *Application {
 	r.Fetch = &[]Fetch{}
 
+	return r
+}
+
+// SetUpgradeStrategy sets the upgrade strategy.
+func (r *Application) SetUpgradeStrategy(us UpgradeStrategy) *Application {
+	r.UpgradeStrategy = &us
+	return r
+}
+
+// EmptyUpgradeStrategy explicitly empties the upgrade strategy -- use this if
+// you need to empty the upgrade strategy of an application that already has
+// the upgrade strategy set (setting it to nil will keep the current value).
+func (r *Application) EmptyUpgradeStrategy() *Application {
+	r.UpgradeStrategy = &UpgradeStrategy{}
 	return r
 }
 
@@ -807,7 +844,7 @@ func (i *IPAddressPerTask) AddGroup(group string) *IPAddressPerTask {
 // SetDiscovery define the discovery to an IPAddressPerTask
 //  discovery: The discovery struct
 func (i *IPAddressPerTask) SetDiscovery(discovery Discovery) *IPAddressPerTask {
-	i.Discovery = discovery
+	i.Discovery = &discovery
 	return i
 }
 

--- a/vendor/github.com/gambol99/go-marathon/client.go
+++ b/vendor/github.com/gambol99/go-marathon/client.go
@@ -198,7 +198,7 @@ func NewClient(config Config) (Marathon, error) {
 	}
 
 	// step: create a new cluster
-	hosts, err := newCluster(config.HTTPClient, config.URL)
+	hosts, err := newCluster(config.HTTPClient, config.URL, config.DCOSToken != "")
 	if err != nil {
 		return nil, err
 	}
@@ -246,24 +246,11 @@ func (r *marathonClient) apiDelete(uri string, post, result interface{}) error {
 	return r.apiCall("DELETE", uri, post, result)
 }
 
-func (r *marathonClient) apiCall(method, uri string, body, result interface{}) error {
+func (r *marathonClient) apiCall(method, url string, body, result interface{}) error {
 	for {
-		// step: grab a member from the cluster and attempt to perform the request
-		member, err := r.hosts.getMember()
-		if err != nil {
-			return ErrMarathonDown
-		}
-
-		// step: Create the endpoint url
-		url := fmt.Sprintf("%s/%s", member, uri)
-		if r.config.DCOSToken != "" && r.config.DCOSPath != "" {
-			url = fmt.Sprintf("%s/%s/%s", member, r.config.DCOSPath, uri)
-		} else if r.config.DCOSToken != "" {
-			url = fmt.Sprintf("%s/%s", member+"/marathon", uri)
-		}
-
 		// step: marshall the request to json
 		var requestBody []byte
+		var err error
 		if body != nil {
 			if requestBody, err = json.Marshal(body); err != nil {
 				return err
@@ -271,7 +258,7 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 		}
 
 		// step: create the api request
-		request, err := r.buildAPIRequest(method, url, bytes.NewReader(requestBody))
+		request, member, err := r.buildAPIRequest(method, url, bytes.NewReader(requestBody))
 		if err != nil {
 			return err
 		}
@@ -320,11 +307,20 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 }
 
 // buildAPIRequest creates a default API request
-func (r *marathonClient) buildAPIRequest(method, url string, reader io.Reader) (*http.Request, error) {
-	// Make the http request to Marathon
-	request, err := http.NewRequest(method, url, reader)
+func (r *marathonClient) buildAPIRequest(method, uri string, reader io.Reader) (request *http.Request, member string, err error) {
+	// Grab a member from the cluster
+	member, err = r.hosts.getMember()
 	if err != nil {
-		return nil, err
+		return nil, "", ErrMarathonDown
+	}
+
+	// Create the endpoint URL
+	url := fmt.Sprintf("%s/%s", member, uri)
+
+	// Make the http request to Marathon
+	request, err = http.NewRequest(method, url, reader)
+	if err != nil {
+		return nil, member, err
 	}
 
 	// Add any basic auth and the content headers
@@ -339,7 +335,7 @@ func (r *marathonClient) buildAPIRequest(method, url string, reader io.Reader) (
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("Accept", "application/json")
 
-	return request, nil
+	return request, member, nil
 }
 
 var oneLogLineRegex = regexp.MustCompile(`(?m)^\s*`)

--- a/vendor/github.com/gambol99/go-marathon/client.go
+++ b/vendor/github.com/gambol99/go-marathon/client.go
@@ -256,7 +256,9 @@ func (r *marathonClient) apiCall(method, uri string, body, result interface{}) e
 
 		// step: Create the endpoint url
 		url := fmt.Sprintf("%s/%s", member, uri)
-		if r.config.DCOSToken != "" {
+		if r.config.DCOSToken != "" && r.config.DCOSPath != "" {
+			url = fmt.Sprintf("%s/%s/%s", member, r.config.DCOSPath, uri)
+		} else if r.config.DCOSToken != "" {
 			url = fmt.Sprintf("%s/%s", member+"/marathon", uri)
 		}
 

--- a/vendor/github.com/gambol99/go-marathon/cluster.go
+++ b/vendor/github.com/gambol99/go-marathon/cluster.go
@@ -51,7 +51,7 @@ type member struct {
 }
 
 // newCluster returns a new marathon cluster
-func newCluster(client *http.Client, marathonURL string) (*cluster, error) {
+func newCluster(client *http.Client, marathonURL string, isDCOS bool) (*cluster, error) {
 	// step: extract and basic validate the endpoints
 	var members []*member
 	var defaultProto string
@@ -61,29 +61,33 @@ func newCluster(client *http.Client, marathonURL string) (*cluster, error) {
 		if endpoint == "" {
 			return nil, newInvalidEndpointError("endpoint is blank")
 		}
+		// step: prepend scheme if missing on (non-initial) endpoint.
+		if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+			if defaultProto == "" {
+				return nil, newInvalidEndpointError("missing scheme on (first) endpoint")
+			}
+
+			endpoint = fmt.Sprintf("%s://%s", defaultProto, endpoint)
+		}
 		// step: parse the url
 		u, err := url.Parse(endpoint)
 		if err != nil {
-			return nil, newInvalidEndpointError("endpoint: %s is invalid reason: %s", endpoint, err)
+			return nil, newInvalidEndpointError("invalid endpoint '%s': %s", endpoint, err)
 		}
-		// step: set the default protocol schema
 		if defaultProto == "" {
-			if u.Scheme != "http" && u.Scheme != "https" {
-				return nil, newInvalidEndpointError("endpoint: %s protocol must be (http|https)", endpoint)
-			}
 			defaultProto = u.Scheme
-		}
-		// step: does the url have a protocol schema? if not, use the default
-		if u.Scheme == "" || u.Opaque != "" {
-			urlWithScheme := fmt.Sprintf("%s://%s", defaultProto, u.String())
-			if u, err = url.Parse(urlWithScheme); err != nil {
-				panic(fmt.Sprintf("unexpected parsing error for URL '%s' with added default scheme: %s", urlWithScheme, err))
-			}
 		}
 
 		// step: check for empty hosts
 		if u.Host == "" {
 			return nil, newInvalidEndpointError("endpoint: %s must have a host", endpoint)
+		}
+
+		// step: if DCOS is set and no path is given, set the default DCOS path.
+		// done in order to maintain compatibility with automatic addition of the
+		// default DCOS path.
+		if isDCOS && strings.TrimLeft(u.Path, "/") == "" {
+			u.Path = defaultDCOSPath
 		}
 
 		// step: create a new node for this endpoint

--- a/vendor/github.com/gambol99/go-marathon/config.go
+++ b/vendor/github.com/gambol99/go-marathon/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	CallbackURL string
 	// DCOSToken for DCOS environment, This will override the Authorization header
 	DCOSToken string
+	// DCOSPath for additional marathon instances or custom paths
+	DCOSPath string
 	// LogOutput the output for debug log messages
 	LogOutput io.Writer
 	// HTTPClient is the http client

--- a/vendor/github.com/gambol99/go-marathon/config.go
+++ b/vendor/github.com/gambol99/go-marathon/config.go
@@ -25,6 +25,8 @@ import (
 
 const defaultPollingWaitTime = 500 * time.Millisecond
 
+const defaultDCOSPath = "marathon"
+
 // EventsTransport describes which transport should be used to deliver Marathon events
 type EventsTransport int
 
@@ -46,8 +48,6 @@ type Config struct {
 	CallbackURL string
 	// DCOSToken for DCOS environment, This will override the Authorization header
 	DCOSToken string
-	// DCOSPath for additional marathon instances or custom paths
-	DCOSPath string
 	// LogOutput the output for debug log messages
 	LogOutput io.Writer
 	// HTTPClient is the http client

--- a/vendor/github.com/gambol99/go-marathon/deployment.go
+++ b/vendor/github.com/gambol99/go-marathon/deployment.go
@@ -49,8 +49,9 @@ type DeploymentStep struct {
 // StepActions is a series of deployment steps
 type StepActions struct {
 	Actions []struct {
-		Type string `json:"type"`
-		App  string `json:"app"`
+		Action string `json:"action"` // 1.1.2 and after
+		Type   string `json:"type"`   // 1.1.1 and before
+		App    string `json:"app"`
 	}
 }
 
@@ -84,8 +85,14 @@ func (r *marathonClient) Deployments() ([]*Deployment, error) {
 			for stepIndex, step := range steps {
 				deployment.Steps = append(deployment.Steps, make([]*DeploymentStep, len(step.Actions)))
 				for actionIndex, action := range step.Actions {
+					var stepAction string
+					if action.Type != "" {
+						stepAction = action.Type
+					} else {
+						stepAction = action.Action
+					}
 					deployment.Steps[stepIndex][actionIndex] = &DeploymentStep{
-						Action: action.Type,
+						Action: stepAction,
 						App:    action.App,
 					}
 				}

--- a/vendor/github.com/gambol99/go-marathon/info.go
+++ b/vendor/github.com/gambol99/go-marathon/info.go
@@ -30,19 +30,25 @@ type Info struct {
 	} `json:"http_config"`
 	Leader         string `json:"leader"`
 	MarathonConfig struct {
-		Checkpoint                 bool    `json:"checkpoint"`
-		Executor                   string  `json:"executor"`
-		FailoverTimeout            float64 `json:"failover_timeout"`
-		Ha                         bool    `json:"ha"`
-		Hostname                   string  `json:"hostname"`
-		LocalPortMax               float64 `json:"local_port_max"`
-		LocalPortMin               float64 `json:"local_port_min"`
-		Master                     string  `json:"master"`
-		MesosRole                  string  `json:"mesos_role"`
-		MesosUser                  string  `json:"mesos_user"`
-		ReconciliationInitialDelay float64 `json:"reconciliation_initial_delay"`
-		ReconciliationInterval     float64 `json:"reconciliation_interval"`
-		TaskLaunchTimeout          float64 `json:"task_launch_timeout"`
+		Checkpoint                     bool    `json:"checkpoint"`
+		Executor                       string  `json:"executor"`
+		FailoverTimeout                float64 `json:"failover_timeout"`
+		FrameworkName                  string  `json:"framework_name"`
+		Ha                             bool    `json:"ha"`
+		Hostname                       string  `json:"hostname"`
+		LeaderProxyConnectionTimeoutMs float64 `json:"leader_proxy_connection_timeout_ms"`
+		LeaderProxyReadTimeoutMs       float64 `json:"leader_proxy_read_timeout_ms"`
+		LocalPortMax                   float64 `json:"local_port_max"`
+		LocalPortMin                   float64 `json:"local_port_min"`
+		Master                         string  `json:"master"`
+		MesosLeaderUIURL               string  `json:"mesos_leader_ui_url"`
+		WebUIURL                       string  `json:"webui_url"`
+		MesosRole                      string  `json:"mesos_role"`
+		MesosUser                      string  `json:"mesos_user"`
+		ReconciliationInitialDelay     float64 `json:"reconciliation_initial_delay"`
+		ReconciliationInterval         float64 `json:"reconciliation_interval"`
+		TaskLaunchTimeout              float64 `json:"task_launch_timeout"`
+		TaskReservationTimeout         float64 `json:"task_reservation_timeout"`
 	} `json:"marathon_config"`
 	Name            string `json:"name"`
 	Version         string `json:"version"`

--- a/vendor/github.com/gambol99/go-marathon/subscription.go
+++ b/vendor/github.com/gambol99/go-marathon/subscription.go
@@ -167,13 +167,8 @@ func (r *marathonClient) registerSSESubscription() error {
 	if r.subscribedToSSE {
 		return nil
 	}
-	// Get a member from the cluster
-	marathon, err := r.hosts.getMember()
-	if err != nil {
-		return err
-	}
 
-	request, err := r.buildAPIRequest("GET", fmt.Sprintf("%s/%s", marathon, marathonAPIEventStream), nil)
+	request, _, err := r.buildAPIRequest("GET", marathonAPIEventStream, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/gambol99/go-marathon/task.go
+++ b/vendor/github.com/gambol99/go-marathon/task.go
@@ -37,6 +37,7 @@ type Task struct {
 	SlaveID            string               `json:"slaveId"`
 	StagedAt           string               `json:"stagedAt"`
 	StartedAt          string               `json:"startedAt"`
+	State              string               `json:"state"`
 	IPAddresses        []*IPAddress         `json:"ipAddresses"`
 	Version            string               `json:"version"`
 }

--- a/vendor/github.com/gambol99/go-marathon/update_strategy.go
+++ b/vendor/github.com/gambol99/go-marathon/update_strategy.go
@@ -16,8 +16,20 @@ limitations under the License.
 
 package marathon
 
-// UpgradeStrategy is upgrade strategy applied to a application
+// UpgradeStrategy is the upgrade strategy applied to an application.
 type UpgradeStrategy struct {
-	MinimumHealthCapacity float64 `json:"minimumHealthCapacity"`
-	MaximumOverCapacity   float64 `json:"maximumOverCapacity"`
+	MinimumHealthCapacity *float64 `json:"minimumHealthCapacity,omitempty"`
+	MaximumOverCapacity   *float64 `json:"maximumOverCapacity,omitempty"`
+}
+
+// SetMinimumHealthCapacity sets the minimum health capacity.
+func (us UpgradeStrategy) SetMinimumHealthCapacity(cap float64) UpgradeStrategy {
+	us.MinimumHealthCapacity = &cap
+	return us
+}
+
+// SetMaximumOverCapacity sets the maximum over capacity.
+func (us UpgradeStrategy) SetMaximumOverCapacity(cap float64) UpgradeStrategy {
+	us.MaximumOverCapacity = &cap
+	return us
 }


### PR DESCRIPTION
This pull request enables authorization tokens as the authorization mechanism for DCOS; it also makes possible to set the Marathon URL to connect to multiple Marathon instances.

It depends on gambol99/go-marathon#267.